### PR TITLE
Proofread and fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Made by @Howo : https://steemit.com/@howo
 - [How to create an account](https://github.com/drov0/steemsnippets/tree/master/steemjs/create_account)
 - [How to test if an username/password or username/privatekey is correct](https://github.com/drov0/steemsnippets/tree/master/steemjs/test_login)
 - [How to post an article](https://github.com/drov0/steemsnippets/tree/master/steemjs/post)
-- [How to get recent posts](https://github.com/drov0/steemsnppets/tree/master/steemjs/get_new_posts)
+- [How to get recent posts](https://github.com/drov0/steemsnippets/tree/master/steemjs/get_new_posts)
 - [How to comment on an article](https://github.com/drov0/steemsnippets/tree/master/steemjs/comment)
 - [How to cast a vote/flag](https://github.com/drov0/steemsnippets/tree/master/steemjs/vote)
 - [How to get the voting power of an user ](https://github.com/drov0/steemsnippets/tree/master/steemjs/voting_power)

--- a/steemjs/comment/package.json
+++ b/steemjs/comment/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "post",
+  "name": "comment",
   "version": "1.0.0",
   "description": "Comments on an article on the steem blockchain",
   "main": "comment.js",

--- a/steemjs/post/post.js
+++ b/steemjs/post/post.js
@@ -1,7 +1,7 @@
 var steem = require('steem');
 
 /**
- * Creates an account, note that almost no validation is done.
+ * Posts an article to the steem blockchain
  * @param {String} username - username of the account
  * @param {String} password - password of the account
  * @param {String} main_tag - The main tag for the post

--- a/steemjs/power_up/package.json
+++ b/steemjs/power_up/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vote",
+  "name": "power_up",
   "version": "1.0.0",
   "description": "Power up x steem to voting power",
   "main": "power_up.js",

--- a/steemjs/power_up/power_up.js
+++ b/steemjs/power_up/power_up.js
@@ -1,7 +1,7 @@
 var steem = require('steem');
 
 /**
- * Creates an account, note that almost no validation is done.
+ * Powers up tokens into STEEM Power
  * @param {String} username - username of the account
  * @param {String} Activekey - Private active key of the account
  * @param {String} amount - Amount of tokens that you want to power up, note that it must be written like this : x.xxx unit eg : '1.265 STEEM' or '0.010 STEEM'

--- a/steemjs/test_login/test_login.js
+++ b/steemjs/test_login/test_login.js
@@ -5,7 +5,7 @@ var steem = require('steem');
  * Tests if an username/password pair is correct
  * @param {String} username - username of the account
  * @param {String} password - password of the account
- * @return {boolean} valid - True of the password is correct, false if not (or if the account doesn't exists)
+ * @return {boolean} valid - True if the password is correct, false if not (or if the account doesn't exists)
  */
 function login_using_password(username, password) {
     // Get the private posting key
@@ -33,7 +33,7 @@ function login_using_password(username, password) {
  * @param {String} username - username of the account
  * @param {String} wif - Private key used for login
  * @param {String} type - Type of the private key, can be "posting", "active" or "owner"
- * @return {boolean} valid - True of the password is correct, false if not (or if the account doesn't exists)
+ * @return {boolean} valid - True if the password is correct, false if not (or if the account doesn't exists)
  */
 function login_using_wif(username, wif, type) {
     // Get the private posting key

--- a/steemjs/transfer/package.json
+++ b/steemjs/transfer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "post",
+  "name": "transfer",
   "version": "1.0.0",
   "description": "Transfers sp or sbd to another user",
   "main": "transfer.js",

--- a/steemjs/use_testnet/package.json
+++ b/steemjs/use_testnet/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "use_testnert",
+  "name": "use_testnet",
   "version": "1.0.0",
   "description": "How to use the testnet",
   "main": "use_testnet.js",

--- a/steemjs/vote/vote.js
+++ b/steemjs/vote/vote.js
@@ -5,7 +5,6 @@ var steem = require('steem');
  * @param {String} username - username of the voter account
  * @param {String} password - password of the voter account
  * @param {String} author - Author of the post
- * @param {String} url - permlink of the post eg :
  * @param {String} permlink - permanent link of the post to comment to. eg : https://steemit.com/programming/@howo/introducting-steemsnippets the permlink is "introducting-steemsnippets"
  * @param {int} weight - Power of the vote, can range from -10000 to 10000, 10000 equals a 100% upvote. -10000 equals a 100% flag.
  */

--- a/steemjs/vote/vote.js
+++ b/steemjs/vote/vote.js
@@ -1,7 +1,7 @@
 var steem = require('steem');
 
 /**
- * Creates an account, note that almost no validation is done.
+ * Casts a vote.
  * @param {String} username - username of the voter account
  * @param {String} password - password of the voter account
  * @param {String} author - Author of the post

--- a/steemjs/voting_power/package.json
+++ b/steemjs/voting_power/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "post",
+  "name": "voting_power",
   "version": "1.0.0",
   "description": "Gets the voting power of an user",
   "main": "voting_power.js",


### PR DESCRIPTION
Fixed in this PR:

- A few `package.json` files had `'name'` property the same as another package;
- Some snippets had jsdocs description pasted from another snippet, usually `create_user`;
- Fixed a typo I introduced to README in #1 that caused a broken link;
- Misc. minor typos and fixes in comments.

 I used tiny commits to make it easier to cherry pick in case you disagree with any of my edits, @drov0  :)

Thanks!